### PR TITLE
Always retry alternatives.install state

### DIFF
--- a/rubymine/linuxenv.sls
+++ b/rubymine/linuxenv.sls
@@ -31,6 +31,9 @@ rubymine-home-alt-install:
     - link: '{{ rubymine.jetbrains.home }}/rubymine'
     - path: '{{ rubymine.jetbrains.realhome }}'
     - priority: {{ rubymine.linux.altpriority }}
+    - retry:
+        attempts: 2
+        until: True
 
 rubymine-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ rubymine-home-alt-set:
     - path: {{ rubymine.jetbrains.realhome }}
     - onchanges:
       - alternatives: rubymine-home-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
 # Add intelli to alternatives system
 rubymine-alt-install:
@@ -49,6 +55,9 @@ rubymine-alt-install:
     - require:
       - alternatives: rubymine-home-alt-install
       - alternatives: rubymine-home-alt-set
+    - retry:
+        attempts: 2
+        until: True
 
 rubymine-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ rubymine-alt-set:
     - path: {{ rubymine.jetbrains.realcmd }}
     - onchanges:
       - alternatives: rubymine-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
   {% endif %}
 

--- a/rubymine/map.jinja
+++ b/rubymine/map.jinja
@@ -22,9 +22,9 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
-{% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None', '',) %}
-   {%- set pcode = ide.jetbrains.product %}
+{%- set pcode = ide.jetbrains.product %}
+{% if grains.os != 'MacOS' %}
+    {%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
 {% endif %}
 {%- set jdata = salt['cmd.run']('curl {0} {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install ` often fails on 1st run.

Verified on SuSE